### PR TITLE
add bug report mod version to accept versions until 1.3.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugReportV1.yml
+++ b/.github/ISSUE_TEMPLATE/bugReportV1.yml
@@ -41,7 +41,14 @@ body:
       label: Version
       description: What version of the mod are you running?
       options:
-        - 1.3.0 (Latest)
+        - 1.3.7 (Latest)
+        - 1.3.6
+        - 1.3.5
+        - 1.3.4
+        - 1.3.3
+        - 1.3.2
+        - 1.3.1
+        - 1.3.0
         - 1.2.5
         - 1.2.4
         - 1.2.2


### PR DESCRIPTION
Bug report template only accepts mod version until 1.3.0 (latest).
This PR allows you to report for all mod versions until 1.3.7.
